### PR TITLE
Improve styling of flat map

### DIFF
--- a/home/templates/home/map.html
+++ b/home/templates/home/map.html
@@ -5,24 +5,19 @@
 	.wrapper {
 	  display: grid;
 	  grid-gap: 1em;
-	  grid-template-columns: 1fr 1fr;
+	  grid-template-columns: 1fr 2fr;
 	}
 
 	.building28 {
 	  display: grid;
 	  grid-gap: 0.5em;
 	  grid-template-areas:
-	    "h  h"
-	    "f7 ."
+	    "h  h "
 	    "f7 ."
 	    "f6 f5"
-	    "f6 f5"
-	    "f4 f3"
 	    "f4 f3"
 	    "f2 f1"
-	    "f2 f1"
-	    "b b";
-  	  grid-template-rows: 37px repeat(9,   1fr);
+	    "b b"
 	}
 
 	.building28 > div {
@@ -61,7 +56,7 @@
 
 	.building34 > div {
 	  display: grid;
-	  grid-template-columns: 1fr 1fr;
+	  grid-template-columns: 1fr 1fr 1fr;
 	  grid-gap: 0.5em;
 	  border: #CCC 1px solid;
 	  padding: 0.5em;

--- a/home/templates/home/map.html
+++ b/home/templates/home/map.html
@@ -5,7 +5,7 @@
 	.wrapper {
 	  display: grid;
 	  grid-gap: 1em;
-	  grid-template-columns: 1fr 2fr;
+	  grid-template-columns: 1fr 1fr;
 	}
 
 	.building28 {
@@ -55,7 +55,7 @@
 
 	.building34 > div {
 	  display: grid;
-	  grid-template-columns: 1fr 1fr 1fr;
+	  grid-template-columns: 1fr 1fr;
 	  grid-gap: 0.5em;
 	  border: #CCC 1px solid;
 	  padding: 0.5em;

--- a/home/templates/home/map.html
+++ b/home/templates/home/map.html
@@ -227,26 +227,5 @@
 		    </div>
 	    </div>
 	</div>
-    <div class="col-lg-offset-1 col-sm-8 col-md-8">
-		<h1>List</h1>
-		<h4>Based on signed leases</h4>
-		{% if leases %}
-			<table class="table">
-				<thead>
-					<th>Name</th>
-					<th>Room</th>
-				</thead>
-				<tbody>
-				{% for lease in leases %}
-				<tr>
-					<td>{{lease.user.first_name}} {{lease.user.last_name}}</td>
-					<td>{{ lease.building }}/{{ lease.flat }} {{ lease.room }} </td>
-				</tr>
-				{% endfor %}
-				</tbody>
-			</table>
-		{% endif %}
-	</div>
-</div>
 
 {% endblock body %}

--- a/home/templates/home/map.html
+++ b/home/templates/home/map.html
@@ -12,11 +12,17 @@
 	  display: grid;
 	  grid-gap: 0.5em;
 	  grid-template-areas:
-	    "h  h "
+	    "h  h"
+	    "f7 ."
 	    "f7 ."
 	    "f6 f5"
+	    "f6 f5"
+	    "f4 f3"
 	    "f4 f3"
 	    "f2 f1"
+	    "f2 f1"
+	    "b b";
+  	  grid-template-rows: 37px repeat(9,   1fr);
 	}
 
 	.building28 > div {

--- a/home/templates/home/map.html
+++ b/home/templates/home/map.html
@@ -79,6 +79,21 @@
 	.b16 {grid-area: b16}
 	.b17 {grid-area: b17}
 
+  .f3,
+  .f4,
+  .f7,
+  .b1,
+  .b6,
+  .b7,
+  .b8,
+  .b9,
+  .b14,
+  .b15,
+  .b16,
+  .b17 {
+    background-color: #f7f7f7;
+  }
+
 	@media screen and (max-width: 800px) {
 	.wrapper {
     display: grid;


### PR DESCRIPTION
### Before
![image](https://user-images.githubusercontent.com/6676843/152442954-e6d62cf3-b1c0-4c2b-a526-14bb0e8fc319.png)

### After
![image](https://user-images.githubusercontent.com/6676843/153035954-603c9e7a-34a7-400b-8d4d-4ed7cf502467.png)

* alternating grey/white per floor 
* better align the two buildings (27 flat's 1 and 2 line up with the first floor of 34)
* remove the pointless list at the bottom of the page