### PR TITLE
Show Nextcloud Calendar on intranet home

### DIFF
--- a/home/templates/home/index.html
+++ b/home/templates/home/index.html
@@ -105,6 +105,8 @@
             </a>
             <a target="_blank" href="https://nextcloud.eshc.coop/f/2802" class="list-group-item list-group-item-action"><span
                     class="bi bi-pencil"></span> GM Agendas and Minutes (on Nextcloud)</a>
+            <a target="_blank" href="https://nextcloud.eshc.coop/apps/calendar" class="list-group-item list-group-item-action"><span
+                    class="bi bi-calendar-event"></span> Nextcloud Calendar</a>
             <a href="{% url 'home:wsp' %}" class="list-group-item list-group-item-action"><span
                     class="bi bi-wrench"></span> Work Share Plan</a>
             <a href="{% url 'home:laundry' %}" class="list-group-item list-group-item-action"><span
@@ -115,8 +117,8 @@
                     class="bi bi-cash"></span> Cash Overview</a>
             <a href="{% url 'whiteboard:index' %}" class="list-group-item list-group-item-action"><span
                     class="bi bi-clipboard"></span> The Whiteboard</a>
-						<a href="{% url 'wiki:root' %}" class="list-group-item list-group-item-action"><span
-				                    class="bi bi-book"></span> Wiki</a>
+            <a href="{% url 'wiki:root' %}" class="list-group-item list-group-item-action"><span
+                    class="bi bi-book"></span> Wiki</a>
         </div>
 
         <div class="panel panel-default">


### PR DESCRIPTION
This adds an icon for the calendar to the list of links on the intranet page. We would like to eventually have a live preview of the calendar as an iframe to show the user's calendars