### PR TITLE
Add logging configuration

### DIFF
--- a/eshcIntranet/settings.py
+++ b/eshcIntranet/settings.py
@@ -266,6 +266,37 @@ def wiki_restrict_access(article, user):
 WIKI_CAN_READ = wiki_restrict_access
 WIKI_CAN_WRITE = wiki_restrict_access
 
+LOGGING = {
+    "version": 1,  # the dictConfig format version
+    "disable_existing_loggers": False,  # retain the default loggers,
+    "formatters": {
+        "verbose": {
+            "format": "{name} {levelname} {asctime} {module} {process:d} {thread:d} {message}",
+            "style": "{",
+        },
+        "simple": {
+            "format": "{levelname} {message}",
+            "style": "{",
+        },
+    },
+    "handlers": {
+        "file_debug": {
+            "class": "logging.handlers.RotatingFileHandler",
+            "filename": "debug.log",
+            "level": "DEBUG",
+            'formatter': 'verbose',
+            "maxBytes": 1024 * 1024 * 10,   # 10 MB
+            "backupCount": 5,
+        },
+    },
+    "loggers": {
+        "": {
+            "handlers": ["file_debug"],
+            "level": "DEBUG"
+        },
+    }
+}
+
 # Email
 # EMAIL_USE_TLS = True
 # EMAIL_HOST = 'smtp.gmail.com'


### PR DESCRIPTION
Adds a logging configuration for Django.

This will create a log file in  the intranet cage under `/var/www/eshc-intranet/debug.log`. The file fills up to 10 MB and then archives older logs in up to 5 backup files. Hopefully, this will help us find problems with the intranet more quickly.

The logging will already outoput Django errors, but we might want to add custom logging to get better insight gradually. Generally this would be:

```
import logging

logger = logging.getLogger(__name__)
```

at the start of the file, and then use:

```
logger.<LOG_LEVEL>('This is a logging message')
```

where LOG_LEVEL is one of the [logging levels](https://docs.python.org/3/library/logging.html#logging-levels).