### PR TITLE
Add the email check to application too

### DIFF
--- a/apply/views.py
+++ b/apply/views.py
@@ -11,6 +11,8 @@ from django.shortcuts import get_object_or_404, render
 from django.utils.decorators import method_decorator
 from django.views.generic import TemplateView
 
+from utils.utils import is_university_email
+
 from . import models
 import re
 import sys
@@ -70,6 +72,12 @@ class ApplyView(TemplateView):
         if models.Applicant.objects.filter(session=app_session, email=data['email']).count() > 0:
             mistakes.append(
                 'Sorry, but an application with this e-mail address already exists. Please contact us on our main e-mail to change your application details.')
+
+        print(data['email'])
+        print(is_university_email(data['email']))
+        if is_university_email(data['email']):
+            mistakes.append(
+                'Please do NOT use your university email address as this will lead to problems getting your deposit back when you leave the co-op.')
 
         if len(mistakes) == 0:
             # Add application and send e-mail

--- a/home/forms.py
+++ b/home/forms.py
@@ -5,12 +5,7 @@ from django.contrib.auth.models import User
 from home.models import Point, WgUpdate, Minutes
 from users.models import Profile
 
-def is_university_email(value):
-    if value.endswith("ac.uk"):
-        return False
-    else:
-        return True
-
+from utils.utils import is_university_email
 
 class SignupWithProfileForm(SignupForm):
     first_name = forms.CharField(label="First name(s)", min_length=2, max_length=150,
@@ -53,7 +48,7 @@ class SignupWithProfileForm(SignupForm):
     ]
 
     def clean_email(self):
-        if not is_university_email(self.cleaned_data['email']):
+        if is_university_email(self.cleaned_data['email']):
             self.add_error('email', 'Please do NOT use your university email address as this will lead to problems getting your deposit back when you leave the co-op.')
             return False
         return super(SignupWithProfileForm, self).clean_email()

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -1,0 +1,5 @@
+def is_university_email(value):
+    if value.endswith("ac.uk"):
+        return True
+    else:
+        return False


### PR DESCRIPTION
Changed the "is_university_email" function to give a sane output (i.e… answer the question "is this a uni email" rather than "is this NOT a uni email") and added this to the application form too. This was requested by deposits since we'd ideally not have the academic emails on file for applicants either. Also moved the function to a utils file for clarity.