### PR TITLE
Add CSRF origin config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     environment:
       DEBUG: "${DEBUG:-false}"
       SECRET_KEY: "${SECRET_KEY}"
+      ORIGIN: "${ORIGIN:-https://intranet.eshc.coop}"
 
       ## Database
       DB_ENGINE: "${DB_ENGINE}"

--- a/eshcIntranet/configurable_settings.py
+++ b/eshcIntranet/configurable_settings.py
@@ -22,6 +22,8 @@ def getboolenv(key: str, default: bool = False) -> bool:
 
 DEBUG = getboolenv("DEBUG", False)
 SECRET_KEY = require_env("SECRET_KEY")
+# Must include scheme + host e.g. https://intranet.eshc.coop
+CSRF_TRUSTED_ORIGINS = [os.getenv("ORIGIN", "https://intranet.eshc.coop")]
 
 ## Database
 DATABASES = {


### PR DESCRIPTION
Required past django 4.0. See https://docs.djangoproject.com/en/6.0/releases/4.0/#csrf

Required by django 4.0. Didn't show up in debug mode / testing locally.
