### PR TITLE
Fix volume permissions, add static files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,9 @@ COPY --from=builder --chown=nonroot:nonroot /app /app
 # Place executables in the environment at the front of the path
 ENV PATH="/app/.venv/bin:$PATH"
 
+RUN mkdir -p /app/staticfiles /app/mediafiles \
+ && chown -R nonroot:nonroot /app/staticfiles /app/mediafiles
+
 # Use the non-root user to run our application
 USER nonroot
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       - "${APP_PORT:-8000}:8000"
     volumes:
       - mediafiles:/app/mediafiles
+      - staticfiles:/app/staticfiles
     environment:
       DEBUG: "${DEBUG:-false}"
       SECRET_KEY: "${SECRET_KEY}"
@@ -50,3 +51,4 @@ services:
     restart: unless-stopped
 volumes:
   mediafiles:
+  staticfiles:


### PR DESCRIPTION
Running as nonroot in `dockerfile`, need to add a chown to fix permissions since docker-compose mounts named volumes as being owned by root by default.